### PR TITLE
update build-all script to comply to CF plugin naming convention

### DIFF
--- a/scripts/build-all
+++ b/scripts/build-all
@@ -8,9 +8,10 @@ OUT_DIR=$ROOT_DIR/out
 build() {
     local os=$1
     local arch=$2
+    local postfix=$3
 
     GOOS=$os GOARCH=$arch $ROOT_DIR/scripts/build
-    nf="ascli-$os-$arch"
+    nf="ascli.$postfix"
     if [ "$os" == "windows" ]; then
             nf="$nf.exe"
     fi
@@ -18,8 +19,8 @@ build() {
     mv $OUT_DIR/ascli "$OUT_DIR/$nf"
 }
 
-build darwin amd64
-build linux amd64
-build linux 386
-build windows amd64
-build windows 386
+build darwin amd64 osx
+build linux amd64 linux64
+build linux 386 linux32
+build windows amd64 win64
+build windows 386 win32


### PR DESCRIPTION
To make sure the output file name is compliant with the naming convention documented in https://github.com/cloudfoundry/cli-plugin-repo

```
PLUGIN_PATH=$GOPATH/src/my-plugin
PLUGIN_NAME=$(basename $PLUGIN_PATH)

cd $PLUGIN_PATH
GOOS=linux GOARCH=amd64 go build -o ${PLUGIN_NAME}.linux64
GOOS=linux GOARCH=386 go build -o ${PLUGIN_NAME}.linux32
GOOS=windows GOARCH=amd64 go build -o ${PLUGIN_NAME}.win64
GOOS=windows GOARCH=386 go build -o ${PLUGIN_NAME}.win32
GOOS=darwin GOARCH=amd64 go build -o ${PLUGIN_NAME}.osx
```