### PR TITLE
hide the instance change when the scaling action is failed

### DIFF
--- a/src/cli/api/apihelper.go
+++ b/src/cli/api/apihelper.go
@@ -422,8 +422,10 @@ func (helper *APIHelper) GetHistory(startTime, endTime int64, desc bool, page ui
 			scalingType = "scheduled"
 		}
 		status := "succeeded"
+		instanceChange := strconv.Itoa(entry.OldInstances) + "->" + strconv.Itoa(entry.NewInstances)
 		if entry.Status == 1 {
 			status = "failed"
+			instanceChange = ""
 		}
 
 		var adjustment = entry.NewInstances - entry.OldInstances
@@ -434,8 +436,7 @@ func (helper *APIHelper) GetHistory(startTime, endTime int64, desc bool, page ui
 				entry.Reason = fmt.Sprintf("%d instance(s) because %s", adjustment, entry.Message)
 			}
 		}
-		data = append(data, []string{scalingType, status,
-			strconv.Itoa(entry.OldInstances) + "->" + strconv.Itoa(entry.NewInstances),
+		data = append(data, []string{scalingType, status, instanceChange,
 			time.Unix(0, entry.Timestamp).Format(time.RFC3339),
 			entry.Reason, entry.Error,
 		})

--- a/src/cli/api/apihelper_test.go
+++ b/src/cli/api/apihelper_test.go
@@ -952,7 +952,7 @@ var _ = Describe("API Helper Test", func() {
 						for i, row := range data {
 							Expect(row[0]).To(Equal("scheduled"))
 							Expect(row[1]).To(Equal("failed"))
-							Expect(row[2]).To(Equal(strconv.Itoa(i+20+1) + "->" + strconv.Itoa(i+20+2)))
+							Expect(row[2]).To(Equal(""))
 							Expect(row[3]).To(Equal(time.Unix(0, now+int64((i+20)*120*1E9)).Format(time.RFC3339)))
 							Expect(row[4]).To(Equal("fakeReason"))
 							Expect(row[5]).To(Equal("fakeError"))
@@ -1013,7 +1013,7 @@ var _ = Describe("API Helper Test", func() {
 						for i, row := range data {
 							Expect(row[0]).To(Equal("scheduled"))
 							Expect(row[1]).To(Equal("failed"))
-							Expect(row[2]).To(Equal(strconv.Itoa(29-i+1) + "->" + strconv.Itoa(29-i+2)))
+							Expect(row[2]).To(Equal(""))
 							Expect(row[3]).To(Equal(time.Unix(0, now+int64((29-i)*120*1E9)).Format(time.RFC3339)))
 							Expect(row[4]).To(Equal("fakeReason"))
 							Expect(row[5]).To(Equal("fakeError"))

--- a/src/cli/main_test.go
+++ b/src/cli/main_test.go
@@ -2583,7 +2583,6 @@ var _ = Describe("App-AutoScaler Commands", func() {
 											//header line
 										} else {
 											//use (i-1) to skip header
-											Expect(strings.Trim(colomns[2], " ")).To(Equal(strconv.Itoa(i-1+1) + "->" + strconv.Itoa(i-1+2)))
 											Expect(strings.Trim(colomns[3], " ")).To(Equal(time.Unix(0, now.UnixNano()+int64((i-1)*120*1E9)).Format(time.RFC3339)))
 											Expect(strings.Trim(colomns[4], " ")).To(Equal("fakeReason"))
 											Expect(strings.Trim(colomns[5], " ")).To(Equal("fakeError"))
@@ -2591,12 +2590,15 @@ var _ = Describe("App-AutoScaler Commands", func() {
 											if i < 11 {
 												Expect(strings.Trim(colomns[0], " ")).To(Equal("dynamic"))
 												Expect(strings.Trim(colomns[1], " ")).To(Equal("succeeded"))
+												Expect(strings.Trim(colomns[2], " ")).To(Equal(strconv.Itoa(i-1+1) + "->" + strconv.Itoa(i-1+2)))
 											} else if i < 21 {
 												Expect(strings.Trim(colomns[0], " ")).To(Equal("scheduled"))
 												Expect(strings.Trim(colomns[1], " ")).To(Equal("succeeded"))
+												Expect(strings.Trim(colomns[2], " ")).To(Equal(strconv.Itoa(i-1+1) + "->" + strconv.Itoa(i-1+2)))
 											} else {
 												Expect(strings.Trim(colomns[0], " ")).To(Equal("scheduled"))
 												Expect(strings.Trim(colomns[1], " ")).To(Equal("failed"))
+												Expect(strings.Trim(colomns[2], " ")).To(Equal(""))
 											}
 										}
 									}
@@ -2681,19 +2683,21 @@ var _ = Describe("App-AutoScaler Commands", func() {
 											Expect(strings.Trim(colomns[5], " ")).To(Equal("Error"))
 										} else {
 											//use "29-(i-1)" to simulate the expected output in desc order
-											Expect(strings.Trim(colomns[2], " ")).To(Equal(strconv.Itoa(29-(i-1)+1) + "->" + strconv.Itoa(29-(i-1)+2)))
 											Expect(strings.Trim(colomns[3], " ")).To(Equal(time.Unix(0, now.UnixNano()+int64((29-(i-1))*120*1E9)).Format(time.RFC3339)))
 											Expect(strings.Trim(colomns[4], " ")).To(Equal("fakeReason"))
 											Expect(strings.Trim(colomns[5], " ")).To(Equal("fakeError"))
 											if i < 11 {
 												Expect(strings.Trim(colomns[0], " ")).To(Equal("scheduled"))
 												Expect(strings.Trim(colomns[1], " ")).To(Equal("failed"))
+												Expect(strings.Trim(colomns[2], " ")).To(Equal(""))
 											} else if i < 21 {
 												Expect(strings.Trim(colomns[0], " ")).To(Equal("scheduled"))
 												Expect(strings.Trim(colomns[1], " ")).To(Equal("succeeded"))
+												Expect(strings.Trim(colomns[2], " ")).To(Equal(strconv.Itoa(29-(i-1)+1) + "->" + strconv.Itoa(29-(i-1)+2)))
 											} else {
 												Expect(strings.Trim(colomns[0], " ")).To(Equal("dynamic"))
 												Expect(strings.Trim(colomns[1], " ")).To(Equal("succeeded"))
+												Expect(strings.Trim(colomns[2], " ")).To(Equal(strconv.Itoa(29-(i-1)+1) + "->" + strconv.Itoa(29-(i-1)+2)))
 											}
 										}
 									}
@@ -2769,7 +2773,6 @@ var _ = Describe("App-AutoScaler Commands", func() {
 												//header line
 											} else {
 												//use (i-1) to skip header
-												Expect(strings.Trim(colomns[2], " ")).To(Equal(strconv.Itoa(i-1+1) + "->" + strconv.Itoa(i-1+2)))
 												Expect(strings.Trim(colomns[3], " ")).To(Equal(time.Unix(0, now.UnixNano()+int64((i-1)*120*1E9)).Format(time.RFC3339)))
 												Expect(strings.Trim(colomns[4], " ")).To(Equal("fakeReason"))
 												Expect(strings.Trim(colomns[5], " ")).To(Equal("fakeError"))
@@ -2777,12 +2780,18 @@ var _ = Describe("App-AutoScaler Commands", func() {
 												if i < 11 {
 													Expect(strings.Trim(colomns[0], " ")).To(Equal("dynamic"))
 													Expect(strings.Trim(colomns[1], " ")).To(Equal("succeeded"))
+													Expect(strings.Trim(colomns[2], " ")).To(Equal(strconv.Itoa(i-1+1) + "->" + strconv.Itoa(i-1+2)))
+
 												} else if i < 21 {
 													Expect(strings.Trim(colomns[0], " ")).To(Equal("scheduled"))
 													Expect(strings.Trim(colomns[1], " ")).To(Equal("succeeded"))
+													Expect(strings.Trim(colomns[2], " ")).To(Equal(strconv.Itoa(i-1+1) + "->" + strconv.Itoa(i-1+2)))
+
 												} else {
 													Expect(strings.Trim(colomns[0], " ")).To(Equal("scheduled"))
 													Expect(strings.Trim(colomns[1], " ")).To(Equal("failed"))
+													Expect(strings.Trim(colomns[2], " ")).To(Equal(""))
+
 												}
 											}
 										}
@@ -2866,7 +2875,6 @@ var _ = Describe("App-AutoScaler Commands", func() {
 												//header line
 											} else {
 												//use (i-1) to skip header
-												Expect(strings.Trim(colomns[2], " ")).To(Equal(strconv.Itoa(i-1+1) + "->" + strconv.Itoa(i-1+2)))
 												Expect(strings.Trim(colomns[3], " ")).To(Equal(time.Unix(0, now.UnixNano()+int64((i-1)*120*1E9)).Format(time.RFC3339)))
 												Expect(strings.Trim(colomns[4], " ")).To(Equal("fakeReason"))
 												Expect(strings.Trim(colomns[5], " ")).To(Equal("fakeError"))
@@ -2874,12 +2882,18 @@ var _ = Describe("App-AutoScaler Commands", func() {
 												if i < 11 {
 													Expect(strings.Trim(colomns[0], " ")).To(Equal("dynamic"))
 													Expect(strings.Trim(colomns[1], " ")).To(Equal("succeeded"))
+													Expect(strings.Trim(colomns[2], " ")).To(Equal(strconv.Itoa(i-1+1) + "->" + strconv.Itoa(i-1+2)))
+
 												} else if i < 21 {
 													Expect(strings.Trim(colomns[0], " ")).To(Equal("scheduled"))
 													Expect(strings.Trim(colomns[1], " ")).To(Equal("succeeded"))
+													Expect(strings.Trim(colomns[2], " ")).To(Equal(strconv.Itoa(i-1+1) + "->" + strconv.Itoa(i-1+2)))
+
 												} else {
 													Expect(strings.Trim(colomns[0], " ")).To(Equal("scheduled"))
 													Expect(strings.Trim(colomns[1], " ")).To(Equal("failed"))
+													Expect(strings.Trim(colomns[2], " ")).To(Equal(""))
+
 												}
 											}
 										}
@@ -2963,7 +2977,6 @@ var _ = Describe("App-AutoScaler Commands", func() {
 												//header line
 											} else {
 												//use (i-1) to skip header
-												Expect(strings.Trim(colomns[2], " ")).To(Equal(strconv.Itoa(i-1+1) + "->" + strconv.Itoa(i-1+2)))
 												Expect(strings.Trim(colomns[3], " ")).To(Equal(time.Unix(0, now.UnixNano()+int64((i-1)*120*1E9)).Format(time.RFC3339)))
 												Expect(strings.Trim(colomns[4], " ")).To(Equal("fakeReason"))
 												Expect(strings.Trim(colomns[5], " ")).To(Equal("fakeError"))
@@ -2971,12 +2984,18 @@ var _ = Describe("App-AutoScaler Commands", func() {
 												if i < 11 {
 													Expect(strings.Trim(colomns[0], " ")).To(Equal("dynamic"))
 													Expect(strings.Trim(colomns[1], " ")).To(Equal("succeeded"))
+													Expect(strings.Trim(colomns[2], " ")).To(Equal(strconv.Itoa(i-1+1) + "->" + strconv.Itoa(i-1+2)))
+
 												} else if i < 21 {
 													Expect(strings.Trim(colomns[0], " ")).To(Equal("scheduled"))
 													Expect(strings.Trim(colomns[1], " ")).To(Equal("succeeded"))
+													Expect(strings.Trim(colomns[2], " ")).To(Equal(strconv.Itoa(i-1+1) + "->" + strconv.Itoa(i-1+2)))
+
 												} else {
 													Expect(strings.Trim(colomns[0], " ")).To(Equal("scheduled"))
 													Expect(strings.Trim(colomns[1], " ")).To(Equal("failed"))
+													Expect(strings.Trim(colomns[2], " ")).To(Equal(""))
+
 												}
 											}
 										}


### PR DESCRIPTION
before change
```
$ cf ash testScalingPython
Retrieving history for app testScalingPython...
Scaling Type     	Status     	Instance Changes     	Time                          	Action                                                       	Error
dynamic          	failed     	-1->-1               	2018-12-27T06:31:12+08:00     	-1 instance(s) because memoryused < 30MB for 121 seconds     	failed to get app info: failed getting application summary: https://api.eu-gb.cf.test.cloud.ibm.com/v2/apps/8e0117f3-a4f7-4f07-8250-8f223f48c937/summary [502] 502 Bad Gateway
dynamic          	failed     	-1->-1               	2019-01-05T02:54:25+08:00     	-1 instance(s) because memoryused < 30MB for 121 seconds     	failed to get app info: invalid character 'N' after top-level value
```

after change
```
$ cf ash testScalingPython
Retrieving scaling event history for app testScalingPython...
Scaling Type     	Status     	Instance Changes     	Time                          	Action                                                       	Error
dynamic          	failed     	                     	2018-12-27T06:31:12+08:00     	-1 instance(s) because memoryused < 30MB for 121 seconds     	failed to get app info: failed getting application summary: https://api.eu-gb.cf.test.cloud.ibm.com/v2/apps/8e0117f3-a4f7-4f07-8250-8f223f48c937/summary [502] 502 Bad Gateway
dynamic          	failed     	                     	2019-01-05T02:54:25+08:00     	-1 instance(s) because memoryused < 30MB for 121 seconds     	failed to get app info: invalid character 'N' after top-level value
```