### PR TITLE
return all records if start or end is specified and number is not specified

### DIFF
--- a/src/cli/commands/retrieve_history.go
+++ b/src/cli/commands/retrieve_history.go
@@ -55,6 +55,8 @@ func (command HistoryCommand) Execute([]string) error {
 		if rn <= 0 || err != nil {
 			return errors.New(fmt.Sprintf(ui.InvalidRecordNumber, command.RecordNumber))
 		}
+	} else if command.StartTime != "" || command.EndTime != "" {
+		rn = math.MaxInt64
 	}
 	if command.StartTime != "" && command.EndTime != "" {
 		rn = math.MaxInt64
@@ -108,6 +110,7 @@ func RetrieveHistory(cliConnection api.Connection, appName string, startTime, en
 		currentNumber int64  = 0
 		next          bool   = true
 		noResult      bool   = true
+		moreResult    bool   = false
 		data          [][]string
 	)
 
@@ -129,6 +132,9 @@ func RetrieveHistory(cliConnection api.Connection, appName string, startTime, en
 		}
 
 		if !next || currentNumber >= recordNumber {
+			if next && recordNumber == 0 {
+				moreResult = true
+			}
 			break
 		}
 		page += 1
@@ -141,6 +147,9 @@ func RetrieveHistory(cliConnection api.Connection, appName string, startTime, en
 		if outputfile != "" {
 			ui.SayOK()
 		}
+	}
+	if moreResult {
+		ui.SayWarningMessage(ui.MoreRecordsWarning)
 	}
 
 	return nil

--- a/src/cli/commands/retrieve_metrics.go
+++ b/src/cli/commands/retrieve_metrics.go
@@ -66,6 +66,8 @@ func (command MetricsCommand) Execute([]string) error {
 		if rn <= 0 || err != nil {
 			return errors.New(fmt.Sprintf(ui.InvalidRecordNumber, command.RecordNumber))
 		}
+	} else if command.StartTime != "" || command.EndTime != "" {
+		rn = math.MaxInt64
 	}
 	if command.StartTime != "" && command.EndTime != "" {
 		rn = math.MaxInt64
@@ -119,6 +121,7 @@ func RetrieveAggregatedMetrics(cliConnection api.Connection, appName, metricName
 		currentNumber int64  = 0
 		next          bool   = true
 		noResult      bool   = true
+		moreResult    bool   = false
 		data          [][]string
 	)
 	for true {
@@ -139,6 +142,9 @@ func RetrieveAggregatedMetrics(cliConnection api.Connection, appName, metricName
 		}
 
 		if !next || currentNumber >= recordNumber {
+			if next && recordNumber == 0 {
+				moreResult = true
+			}
 			break
 		}
 		page += 1
@@ -153,6 +159,9 @@ func RetrieveAggregatedMetrics(cliConnection api.Connection, appName, metricName
 		if writer != os.Stdout {
 			ui.SayOK()
 		}
+	}
+	if moreResult {
+		ui.SayWarningMessage(ui.MoreRecordsWarning)
 	}
 
 	return nil

--- a/src/cli/commands/retrieve_metrics.go
+++ b/src/cli/commands/retrieve_metrics.go
@@ -42,7 +42,8 @@ func (command MetricsCommand) Execute([]string) error {
 	var (
 		st     int64 = 0
 		et     int64 = time.Now().UnixNano()
-		rn     int64 = 0
+		rn     int64 = math.MaxInt64
+		fpo    bool  = false
 		err    error
 		writer *os.File
 	)
@@ -61,17 +62,13 @@ func (command MetricsCommand) Execute([]string) error {
 	if st > et {
 		return errors.New(fmt.Sprintf(ui.InvalidTimeRange, command.StartTime, command.EndTime))
 	}
-	if command.RecordNumber != "" {
+	if command.RecordNumber != "" && (command.StartTime == "" || command.EndTime == "") {
 		rn, err = strconv.ParseInt(command.RecordNumber, 10, 64)
 		if rn <= 0 || err != nil {
 			return errors.New(fmt.Sprintf(ui.InvalidRecordNumber, command.RecordNumber))
 		}
-	} else if command.StartTime != "" || command.EndTime != "" {
-		rn = math.MaxInt64
 	}
-	if command.StartTime != "" && command.EndTime != "" {
-		rn = math.MaxInt64
-	}
+	fpo = command.RecordNumber == "" && command.StartTime == "" && command.EndTime == ""
 
 	if command.Output != "" {
 		writer, err = os.OpenFile(command.Output, os.O_CREATE|os.O_WRONLY, 0666)
@@ -84,10 +81,10 @@ func (command MetricsCommand) Execute([]string) error {
 	}
 	return RetrieveAggregatedMetrics(AutoScaler.CLIConnection,
 		command.RequiredlArgs.AppName, command.RequiredlArgs.MetricName,
-		st, et, rn, command.Desc, writer, command.Output)
+		st, et, rn, fpo, command.Desc, writer, command.Output)
 }
 
-func RetrieveAggregatedMetrics(cliConnection api.Connection, appName, metricName string, startTime, endTime, recordNumber int64, desc bool, writer io.Writer, outputfile string) error {
+func RetrieveAggregatedMetrics(cliConnection api.Connection, appName, metricName string, startTime, endTime, recordNumber int64, firstPageOnly bool, desc bool, writer io.Writer, outputfile string) error {
 
 	cfclient, err := api.NewCFClient(cliConnection)
 	if err != nil {
@@ -131,7 +128,7 @@ func RetrieveAggregatedMetrics(cliConnection api.Connection, appName, metricName
 		}
 
 		for _, row := range data {
-			if recordNumber == 0 || currentNumber < recordNumber {
+			if currentNumber < recordNumber {
 				table.Add(row)
 				currentNumber++
 			}
@@ -141,10 +138,8 @@ func RetrieveAggregatedMetrics(cliConnection api.Connection, appName, metricName
 			table.Print()
 		}
 
-		if !next || currentNumber >= recordNumber {
-			if next && recordNumber == 0 {
-				moreResult = true
-			}
+		moreResult = next && firstPageOnly
+		if !next || currentNumber >= recordNumber || firstPageOnly {
 			break
 		}
 		page += 1

--- a/src/cli/main_test.go
+++ b/src/cli/main_test.go
@@ -1635,14 +1635,14 @@ var _ = Describe("App-AutoScaler Commands", func() {
 									Expect(session.Out).To(gbytes.Say(ui.ShowAggregatedMetricsHint, metricName, fakeAppName))
 									metricsRaw := bytes.TrimPrefix(session.Out.Contents(), []byte(fmt.Sprintf(ui.ShowAggregatedMetricsHint+"\n", metricName, fakeAppName)))
 									metricsTable := strings.Split(string(bytes.TrimRight(metricsRaw, "\n")), "\n")
-									Expect(len(metricsTable)).To(Equal(11))
+									Expect(len(metricsTable)).To(Equal(12))
 									for i, row := range metricsTable {
 										colomns := strings.Split(row, "\t")
 										if i == 0 {
 											Expect(strings.Trim(colomns[0], " ")).To(Equal("Metrics Name"))
 											Expect(strings.Trim(colomns[1], " ")).To(Equal("Value"))
 											Expect(strings.Trim(colomns[2], " ")).To(Equal("Timestamp"))
-										} else {
+										} else if i != len(metricsTable) - 1 {
 											Expect(strings.Trim(colomns[0], " ")).To(Equal("memoryused"))
 											Expect(strings.Trim(colomns[1], " ")).To(Equal("100MB"))
 											Expect(strings.Trim(colomns[2], " ")).To(Equal(time.Unix(0, now.UnixNano()+int64((i-1)*30*1E9)).Format(time.RFC3339)))
@@ -1951,6 +1951,34 @@ var _ = Describe("App-AutoScaler Commands", func() {
 										metricsRaw := bytes.TrimPrefix(session.Out.Contents(), []byte(fmt.Sprintf(ui.ShowAggregatedMetricsHint+"\n", metricName, fakeAppName)))
 										metricsTable := strings.Split(string(bytes.TrimRight(metricsRaw, "\n")), "\n")
 										Expect(len(metricsTable)).To(Equal(16))
+										for i, row := range metricsTable {
+											colomns := strings.Split(row, "\t")
+											if i == 0 {
+												Expect(strings.Trim(colomns[0], " ")).To(Equal("Metrics Name"))
+												Expect(strings.Trim(colomns[1], " ")).To(Equal("Value"))
+												Expect(strings.Trim(colomns[2], " ")).To(Equal("Timestamp"))
+											} else {
+												Expect(strings.Trim(colomns[0], " ")).To(Equal("memoryused"))
+												Expect(strings.Trim(colomns[1], " ")).To(Equal("100MB"))
+												Expect(strings.Trim(colomns[2], " ")).To(Equal(time.Unix(0, now.UnixNano()+int64((i-1)*30*1E9)).Format(time.RFC3339)))
+											}
+										}
+										Expect(session.ExitCode()).To(Equal(0))
+									})
+
+									It("Succeed to print all of the metrics to stdout with asc order ", func() {
+
+										args = []string{ts.Port(), "autoscaling-metrics", fakeAppName, metricName,
+											"--end", time.Unix(0, lowPrecisionNowInNano+int64(29*30*1E9)).Format(time.RFC3339)}
+
+										session, err = gexec.Start(exec.Command(validPluginPath, args...), GinkgoWriter, GinkgoWriter)
+										Expect(err).NotTo(HaveOccurred())
+										session.Wait()
+
+										Expect(session.Out).To(gbytes.Say(ui.ShowAggregatedMetricsHint, metricName, fakeAppName))
+										metricsRaw := bytes.TrimPrefix(session.Out.Contents(), []byte(fmt.Sprintf(ui.ShowAggregatedMetricsHint+"\n", metricName, fakeAppName)))
+										metricsTable := strings.Split(string(bytes.TrimRight(metricsRaw, "\n")), "\n")
+										Expect(len(metricsTable)).To(Equal(31))
 										for i, row := range metricsTable {
 											colomns := strings.Split(row, "\t")
 											if i == 0 {
@@ -2483,7 +2511,7 @@ var _ = Describe("App-AutoScaler Commands", func() {
 									Expect(session.Out).To(gbytes.Say(ui.ShowHistoryHint, fakeAppName))
 									historyRaw := bytes.TrimPrefix(session.Out.Contents(), []byte(fmt.Sprintf(ui.ShowHistoryHint+"\n", fakeAppName)))
 									historyTable := strings.Split(string(bytes.TrimRight(historyRaw, "\n")), "\n")
-									Expect(len(historyTable)).To(Equal(11))
+									Expect(len(historyTable)).To(Equal(12))
 									for i, row := range historyTable {
 										colomns := strings.Split(row, "\t")
 										if i == 0 {
@@ -2494,7 +2522,7 @@ var _ = Describe("App-AutoScaler Commands", func() {
 											Expect(strings.Trim(colomns[4], " ")).To(Equal("Action"))
 											Expect(strings.Trim(colomns[5], " ")).To(Equal("Error"))
 
-										} else {
+										} else if i != len(historyTable) - 1 {
 											Expect(strings.Trim(colomns[0], " ")).To(Equal("dynamic"))
 											Expect(strings.Trim(colomns[1], " ")).To(Equal("succeeded"))
 											Expect(strings.Trim(colomns[2], " ")).To(Equal(strconv.Itoa(i-1+1) + "->" + strconv.Itoa(i-1+2)))
@@ -2863,6 +2891,56 @@ var _ = Describe("App-AutoScaler Commands", func() {
 										historyRaw := bytes.TrimPrefix(session.Out.Contents(), []byte(fmt.Sprintf(ui.ShowHistoryHint+"\n", fakeAppName)))
 										historyTable := strings.Split(string(bytes.TrimRight(historyRaw, "\n")), "\n")
 										Expect(len(historyTable)).To(Equal(16))
+										for i, row := range historyTable {
+											colomns := strings.Split(row, "\t")
+											if i == 0 {
+												Expect(strings.Trim(colomns[0], " ")).To(Equal("Scaling Type"))
+												Expect(strings.Trim(colomns[1], " ")).To(Equal("Status"))
+												Expect(strings.Trim(colomns[2], " ")).To(Equal("Instance Changes"))
+												Expect(strings.Trim(colomns[3], " ")).To(Equal("Time"))
+												Expect(strings.Trim(colomns[4], " ")).To(Equal("Action"))
+												Expect(strings.Trim(colomns[5], " ")).To(Equal("Error"))
+												//header line
+											} else {
+												//use (i-1) to skip header
+												Expect(strings.Trim(colomns[3], " ")).To(Equal(time.Unix(0, now.UnixNano()+int64((i-1)*120*1E9)).Format(time.RFC3339)))
+												Expect(strings.Trim(colomns[4], " ")).To(Equal("fakeReason"))
+												Expect(strings.Trim(colomns[5], " ")).To(Equal("fakeError"))
+
+												if i < 11 {
+													Expect(strings.Trim(colomns[0], " ")).To(Equal("dynamic"))
+													Expect(strings.Trim(colomns[1], " ")).To(Equal("succeeded"))
+													Expect(strings.Trim(colomns[2], " ")).To(Equal(strconv.Itoa(i-1+1) + "->" + strconv.Itoa(i-1+2)))
+
+												} else if i < 21 {
+													Expect(strings.Trim(colomns[0], " ")).To(Equal("scheduled"))
+													Expect(strings.Trim(colomns[1], " ")).To(Equal("succeeded"))
+													Expect(strings.Trim(colomns[2], " ")).To(Equal(strconv.Itoa(i-1+1) + "->" + strconv.Itoa(i-1+2)))
+
+												} else {
+													Expect(strings.Trim(colomns[0], " ")).To(Equal("scheduled"))
+													Expect(strings.Trim(colomns[1], " ")).To(Equal("failed"))
+													Expect(strings.Trim(colomns[2], " ")).To(Equal(""))
+
+												}
+											}
+										}
+										Expect(session.ExitCode()).To(Equal(0))
+									})
+
+									It("Succeed to print all of the history to stdout with asc order ", func() {
+
+										args = []string{ts.Port(), "autoscaling-history", fakeAppName,
+											"--end", time.Unix(0, lowPrecisionNowInNano).Format(time.RFC3339)}
+
+										session, err = gexec.Start(exec.Command(validPluginPath, args...), GinkgoWriter, GinkgoWriter)
+										Expect(err).NotTo(HaveOccurred())
+										session.Wait()
+
+										Expect(session.Out).To(gbytes.Say(ui.ShowHistoryHint, fakeAppName))
+										historyRaw := bytes.TrimPrefix(session.Out.Contents(), []byte(fmt.Sprintf(ui.ShowHistoryHint+"\n", fakeAppName)))
+										historyTable := strings.Split(string(bytes.TrimRight(historyRaw, "\n")), "\n")
+										Expect(len(historyTable)).To(Equal(31))
 										for i, row := range historyTable {
 											colomns := strings.Split(row, "\t")
 											if i == 0 {

--- a/src/cli/ui/message.go
+++ b/src/cli/ui/message.go
@@ -39,5 +39,5 @@ const (
 	AggregatedMetricsNotFound = "No aggregated %s metrics were found for app %s."
 	HistoryNotFound           = "No event history were found for app %s."
 
-	MoreRecordsWarning = "There are more records, and only first page were displayed currently."
+	MoreRecordsWarning = "More records available for app %s. Please re-run the command with --start, --end or --number option to fetch more."
 )

--- a/src/cli/ui/message.go
+++ b/src/cli/ui/message.go
@@ -38,4 +38,6 @@ const (
 
 	AggregatedMetricsNotFound = "No aggregated %s metrics were found for app %s."
 	HistoryNotFound           = "No event history were found for app %s."
+
+	MoreRecordsWarning = "There are more records, and only first page were displayed currently."
 )

--- a/src/cli/ui/ui.go
+++ b/src/cli/ui/ui.go
@@ -19,3 +19,8 @@ func SayFailed() {
 func SayMessage(message string, args ...interface{}) {
 	fmt.Printf(message+"\n", args...)
 }
+
+func SayWarningMessage(message string) {
+	c := color.New(color.FgYellow).Add(color.Bold)
+	c.Println(message)
+}


### PR DESCRIPTION
### 1. when both `--start` and `--end` are specified, all of the records in this duration will be returned no matter `--number`is defined or not
```
$ cf asm TestApp throughput --start "2019-01-19T04:30:00Z" --end "2019-01-19T06:30:00Z" -n 2
Retrieving aggregated throughput metrics for app TestApp...
Metrics Name     	Value     	Timestamp
throughput       	0rps      	2019-01-19T12:30:12+08:00
...178 more...
throughput       	0rps      	2019-01-19T14:29:34+08:00

$ cf asm TestApp throughput --start "2019-01-19T04:30:00Z" --end "2019-01-19T06:30:00Z"
Retrieving aggregated throughput metrics for app TestApp...
Metrics Name     	Value     	Timestamp
throughput       	0rps      	2019-01-19T12:30:12+08:00
...178 more...
throughput       	0rps      	2019-01-19T14:29:34+08:00
```

### 2. when one of `--start` and `--end` is specified
#### (1) `--number` is not defined: return all of the records
```
$ cf asm TestApp throughput --start "2019-01-25T02:20:00Z"
Retrieving aggregated throughput metrics for app TestApp...
Metrics Name     	Value     	Timestamp
throughput       	0rps      	2019-01-25T10:20:11+08:00
...312 more...
throughput       	0rps      	2019-01-25T13:38:11+08:00

$ cf asm TestApp throughput --end "2019-01-18T06:30:00Z"
Retrieving aggregated throughput metrics for app TestApp...
Metrics Name     	Value     	Timestamp
throughput       	0rps      	2019-01-18T13:22:53+08:00
...99 more...
throughput       	0rps      	2019-01-18T14:29:33+08:00
```
#### (2) `--number` is defined: return the limited record as `--number` defined
```
$ cf asm TestApp throughput --start "2019-01-25T02:20:00Z" -n 2
Retrieving aggregated throughput metrics for app TestApp...
Metrics Name     	Value     	Timestamp
throughput       	0rps      	2019-01-25T10:20:11+08:00
throughput       	0rps      	2019-01-25T10:20:51+08:00

$ cf asm TestApp throughput --end "2019-01-18T06:30:00Z" -n 2
Retrieving aggregated throughput metrics for app TestApp...
Metrics Name     	Value     	Timestamp
throughput       	0rps      	2019-01-18T13:22:53+08:00
throughput       	0rps      	2019-01-18T13:23:33+08:00
```

### 3. when `--start` and `--end` are not specified
#### (1) `--number` is not defined: return first page of the records with a prompt msg
```
$ cf asm TestApp throughput
Retrieving aggregated throughput metrics for app TestApp...
Metrics Name     	Value     	Timestamp
throughput       	0rps      	2019-01-18T13:22:53+08:00
...48 more...
throughput       	0rps      	2019-01-18T13:55:34+08:00
More records available for app TestApp. Please re-run the command with --start, --end or --number option to fetch more.
```
#### (2) `--number` is defined: return the limited record as `--number` defined
```
$ cf asm TestApp throughput -n 2
Retrieving aggregated throughput metrics for app TestApp...
Metrics Name     	Value     	Timestamp
throughput       	0rps      	2019-01-18T13:22:53+08:00
throughput       	0rps      	2019-01-18T13:23:33+08:00
```